### PR TITLE
Add UI tests to the CI

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -1,0 +1,19 @@
+name: 'Setup Python Environment'
+description: 'Sets up Python and installs dependencies'
+runs:
+  using: "composite"
+  steps:
+    - name: "Install uv"
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
+
+    - name: "Set up Python"
+      uses: actions/setup-python@v5
+      with:
+        python-version-file: ".python-version"
+
+    - name: "Install dependencies"
+      run: make install
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,11 @@ jobs:
         run: |
           uv sync --all-extras --dev --all-packages
 
-      - name: "Install npm dependencies"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Install dependencies
         run: |
           npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright/python:v1.55.0-noble
-      options: --ipc=host
+      options: --ipc=host --user 1001
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,36 @@ jobs:
         run: |
           make test-api
 
-  # TODO add e2e ui tests
+  test-ui:
+    name: "Run UI tests"
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright/python:v1.55.0-noble
+      options: --ipc=host
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Install uv"
+        run: pip install uv
+
+      - name: "Install project dependencies"
+        # TODO sync only frontend package group
+        run: uv sync --all-extras --dev --all-packages
+
+      - name: "Install chromium and dependencies"
+        run: npx playwright install --with-deps chromium
+
+      - name: "Run UI tests"
+        run: uv run --package frontend -- pytest -v packages/frontend/tests
+        env:
+          PLAYWRIGHT_TRACING: True
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-traces
+          path: /tmp/playwright_traces/
 
   # TODO add security checks
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,20 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Install uv"
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - name: "Set up Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: ".python-version"
-
-      - name: "Install dependencies"
-        run: |
-          make install
+      - name: "Setup Python environment"
+        uses: ./.github/actions/setup-python-env
 
       - name: "Lint with ruff"
         run: |
@@ -51,20 +39,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Install uv"
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - name: "Set up Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: ".python-version"
-
-      - name: "Install dependencies"
-        run: |
-          make install
+      - name: "Setup Python environment"
+        uses: ./.github/actions/setup-python-env
 
       # api client version should be committed in the repository
       # so re-generating it in the CI is skipped unless explicitly requested

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: "Install uv"
         run: |
-          pip install uv
+          pip install --user uv
 
       - name: "Install project dependencies"
         # TODO sync only frontend package group

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,17 +66,25 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Install uv"
-        run: pip install uv
+        run: |
+          pip install uv
 
       - name: "Install project dependencies"
         # TODO sync only frontend package group
-        run: uv sync --all-extras --dev --all-packages
+        run: |
+          uv sync --all-extras --dev --all-packages
+
+      - name: "Install npm dependencies"
+        run: |
+          npm ci
 
       - name: "Install chromium and dependencies"
-        run: npx playwright install --with-deps chromium
+        run: |
+          npx playwright install --with-deps chromium
 
       - name: "Run UI tests"
-        run: uv run --package frontend -- pytest -v packages/frontend/tests
+        run: |
+          uv run --package frontend -- pytest -v packages/frontend/tests
         env:
           PLAYWRIGHT_TRACING: True
 

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ test-api:
 
 test-ui: start-playwright-server
 	@echo "Running UI E2E tests..."
-	uv run --package frontend -- pytest -v packages/frontend/tests
+	PLAYWRIGHT_WS_ENDPOINT=ws://0.0.0.0:19323 uv run --package frontend -- pytest -v packages/frontend/tests
 
 start-playwright-server:
 	@echo "Starting Playwright server..."


### PR DESCRIPTION
- add UI test job to the CI workflow
  -  refactor browser fixture so that it can launch local browser when in CI
  - extract remote browser web socket address to an env var
- extract python env setup in CI to a separate action